### PR TITLE
First look and property mapping

### DIFF
--- a/GAS/first_look.py
+++ b/GAS/first_look.py
@@ -7,7 +7,6 @@ import pyspeckit
 from pyspeckit.parallel_map import parallel_map
 from astropy import log
 from spectral_cube import SpectralCube
-from signal_id import Noise
 
 def create_index( a, b):
     """ create_index takes two arrays and it creates an array that covers all indices 

--- a/GAS/run_first_look.py
+++ b/GAS/run_first_look.py
@@ -237,7 +237,7 @@ def FirstLook_L1455():
     a_rms = [   0, 350]  
     b_rms = [ 290, 648]
     index_rms=first_look.create_index( a_rms, b_rms)
-    index_peak=np.arange(260,390)  
+    index_peak=np.arange(309,334)  
     file_in='L1455/L1455_C2S.fits'
     file_out=file_in.replace('.fits','_base1.fits')
     file_new=first_look.baseline( file_in, file_out, index_clean=index_rms, polyorder=1)
@@ -247,7 +247,7 @@ def FirstLook_L1455():
     a_rms = [   0, 350]  
     b_rms = [ 290, 648]
     index_rms=first_look.create_index( a_rms, b_rms)
-    index_peak=np.arange(260,390)  
+    index_peak=np.arange(315,325)  
     file_in='L1455/L1455_HC5N.fits'
     file_out=file_in.replace('.fits','_base1.fits')
     file_new=first_look.baseline( file_in, file_out, index_clean=index_rms, polyorder=1)
@@ -255,19 +255,19 @@ def FirstLook_L1455():
 
     print("Now HC7N_21_20")
     a_rms = [   0, 180]  
-    b_rms = [ 130, 295]
+    b_rms = [ 130, 275]
     index_rms=first_look.create_index( a_rms, b_rms)
-    index_peak=np.arange(120,190)  
+    index_peak=np.arange(128,147)  
     file_in='L1455/L1455_HC7N_21_20.fits'
     file_out=file_in.replace('.fits','_base1.fits')
     file_new=first_look.baseline( file_in, file_out, index_clean=index_rms, polyorder=1)
     first_look.peak_rms( file_new, index_rms=index_rms, index_peak=index_peak)
 
     print("Now HC7N_22_21")
-    a_rms = [   0, 180]  # No lines. Using the same as HC7N_21_20
-    b_rms = [ 130, 295]  # No lines. Using the same as HC7N_21_20
+    a_rms = [   0, 340]  # No lines. Using the same as HC7N_21_20
+    b_rms = [ 290, 648]  # No lines. Using the same as HC7N_21_20
     index_rms=first_look.create_index( a_rms, b_rms)
-    index_peak=np.arange(120,190)  # No lines. Using the same as HC7N_21_20
+    index_peak=np.arange(308,328)  # No lines. Using the same as HC7N_21_20
     file_in='L1455/L1455_HC7N_22_21.fits'
     file_out=file_in.replace('.fits','_base1.fits')
     file_new=first_look.baseline( file_in, file_out, index_clean=index_rms, polyorder=1)

--- a/GAS/run_grid_regions.py
+++ b/GAS/run_grid_regions.py
@@ -78,8 +78,8 @@ def grid_L1455():
     endChannel = 1024 + 1350 # No Lines. Using the same as previous
     gridregion.griddata( rootdir=data_dir, region=region_name, dirname=region_name+'_HC5N',
         startChannel = startChannel, endChannel = endChannel, templateHeader=hd_temp)
-    startChannel = 1024 + 700 # No Lines. Using the same as previous 
-    endChannel = 1024 + 1350  # No Lines. Using the same as previous
+    startChannel = 1024 + 700 + 180 # No Lines. Reduce channel range to avoid absorption from frequency switching
+    endChannel   = 1024 + 700 + 460 # No Lines. Reduce channel range to avoid absorption from frequency switching
     gridregion.griddata( rootdir=data_dir, region=region_name, dirname=region_name+'_HC7N_21_20',
         startChannel = startChannel, endChannel = endChannel, templateHeader=hd_temp)
     startChannel = 1024 + 700 # No Lines. Using the same as previous

--- a/GAS/run_grid_regions.py
+++ b/GAS/run_grid_regions.py
@@ -42,15 +42,36 @@ def grid_NGC1333():
     print("You will image the GBT Ammonia Survey data for NGC1333")
     data_dir='/lustre/pipeline/scratch/GAS'
     region_name='NGC1333'
-    gridregion.griddata( rootdir=data_dir, region=region_name, dirname=region_name+'_NH3_11')
+    startChannel = 1024 + 655 # default 1024
+    endChannel = 1024 + 1418  # default 3072
+    gridregion.griddata( rootdir=data_dir, region=region_name, dirname=region_name+'_NH3_11', 
+        startChannel = startChannel, endChannel = endChannel)
     
     hd_temp=fits.getheader(region_name+'_NH3_11.fits')
-    gridregion.griddata( rootdir=data_dir, region=region_name, dirname=region_name+'_NH3_22',     templateHeader=hd_temp)
-    gridregion.griddata( rootdir=data_dir, region=region_name, dirname=region_name+'_NH3_33',     templateHeader=hd_temp)
-    gridregion.griddata( rootdir=data_dir, region=region_name, dirname=region_name+'_C2S',        templateHeader=hd_temp)
-    gridregion.griddata( rootdir=data_dir, region=region_name, dirname=region_name+'_HC5N',       templateHeader=hd_temp)
-    gridregion.griddata( rootdir=data_dir, region=region_name, dirname=region_name+'_HC7N_21_20', templateHeader=hd_temp)
-    gridregion.griddata( rootdir=data_dir, region=region_name, dirname=region_name+'_HC7N_22_21', templateHeader=hd_temp)
+    startChannel = 1024 + 700
+    endChannel = 1024 + 1350
+    gridregion.griddata( rootdir=data_dir, region=region_name, dirname=region_name+'_NH3_22',     templateHeader=hd_temp,
+        startChannel = startChannel, endChannel = endChannel, templateHeader=hd_temp)
+    startChannel = 1024 + 700
+    endChannel = 1024 + 1350
+    gridregion.griddata( rootdir=data_dir, region=region_name, dirname=region_name+'_NH3_33',     templateHeader=hd_temp,
+        startChannel = startChannel, endChannel = endChannel, templateHeader=hd_temp)
+    startChannel = 1024 + 700
+    endChannel = 1024 + 1350
+    gridregion.griddata( rootdir=data_dir, region=region_name, dirname=region_name+'_C2S',        templateHeader=hd_temp,
+        startChannel = startChannel, endChannel = endChannel, templateHeader=hd_temp)
+    startChannel = 1024 + 700
+    endChannel = 1024 + 1350
+    gridregion.griddata( rootdir=data_dir, region=region_name, dirname=region_name+'_HC5N',       templateHeader=hd_temp,
+        startChannel = startChannel, endChannel = endChannel, templateHeader=hd_temp)
+    startChannel = 1024 + 880
+    endChannel = 1024 + 1160
+    gridregion.griddata( rootdir=data_dir, region=region_name, dirname=region_name+'_HC7N_21_20', templateHeader=hd_temp,
+        startChannel = startChannel, endChannel = endChannel, templateHeader=hd_temp)
+    startChannel = 1024 + 700
+    endChannel = 1024 + 1350
+    gridregion.griddata( rootdir=data_dir, region=region_name, dirname=region_name+'_HC7N_22_21', templateHeader=hd_temp,
+        startChannel = startChannel, endChannel = endChannel, templateHeader=hd_temp)
 
 def grid_L1455():
     print("You will image the GBT Ammonia Survey data for L1455")

--- a/GAS/run_grid_regions.py
+++ b/GAS/run_grid_regions.py
@@ -50,27 +50,27 @@ def grid_NGC1333():
     hd_temp=fits.getheader(region_name+'_NH3_11.fits')
     startChannel = 1024 + 700
     endChannel = 1024 + 1350
-    gridregion.griddata( rootdir=data_dir, region=region_name, dirname=region_name+'_NH3_22',     templateHeader=hd_temp,
+    gridregion.griddata( rootdir=data_dir, region=region_name, dirname=region_name+'_NH3_22',
         startChannel = startChannel, endChannel = endChannel, templateHeader=hd_temp)
     startChannel = 1024 + 700
     endChannel = 1024 + 1350
-    gridregion.griddata( rootdir=data_dir, region=region_name, dirname=region_name+'_NH3_33',     templateHeader=hd_temp,
+    gridregion.griddata( rootdir=data_dir, region=region_name, dirname=region_name+'_NH3_33',
         startChannel = startChannel, endChannel = endChannel, templateHeader=hd_temp)
     startChannel = 1024 + 700
     endChannel = 1024 + 1350
-    gridregion.griddata( rootdir=data_dir, region=region_name, dirname=region_name+'_C2S',        templateHeader=hd_temp,
+    gridregion.griddata( rootdir=data_dir, region=region_name, dirname=region_name+'_C2S', 
         startChannel = startChannel, endChannel = endChannel, templateHeader=hd_temp)
     startChannel = 1024 + 700
     endChannel = 1024 + 1350
-    gridregion.griddata( rootdir=data_dir, region=region_name, dirname=region_name+'_HC5N',       templateHeader=hd_temp,
+    gridregion.griddata( rootdir=data_dir, region=region_name, dirname=region_name+'_HC5N', 
         startChannel = startChannel, endChannel = endChannel, templateHeader=hd_temp)
     startChannel = 1024 + 880
     endChannel = 1024 + 1160
-    gridregion.griddata( rootdir=data_dir, region=region_name, dirname=region_name+'_HC7N_21_20', templateHeader=hd_temp,
+    gridregion.griddata( rootdir=data_dir, region=region_name, dirname=region_name+'_HC7N_21_20', 
         startChannel = startChannel, endChannel = endChannel, templateHeader=hd_temp)
     startChannel = 1024 + 700
     endChannel = 1024 + 1350
-    gridregion.griddata( rootdir=data_dir, region=region_name, dirname=region_name+'_HC7N_22_21', templateHeader=hd_temp,
+    gridregion.griddata( rootdir=data_dir, region=region_name, dirname=region_name+'_HC7N_22_21', 
         startChannel = startChannel, endChannel = endChannel, templateHeader=hd_temp)
 
 def grid_L1455():

--- a/GAS/run_grid_regions.py
+++ b/GAS/run_grid_regions.py
@@ -78,8 +78,8 @@ def grid_L1455():
     endChannel = 1024 + 1350 # No Lines. Using the same as previous
     gridregion.griddata( rootdir=data_dir, region=region_name, dirname=region_name+'_HC5N',
         startChannel = startChannel, endChannel = endChannel, templateHeader=hd_temp)
-    startChannel = 1024 + 1750 
-    endChannel = 1024 + 2048 
+    startChannel = 1024 + 700 # No Lines. Using the same as previous 
+    endChannel = 1024 + 1350  # No Lines. Using the same as previous
     gridregion.griddata( rootdir=data_dir, region=region_name, dirname=region_name+'_HC7N_21_20',
         startChannel = startChannel, endChannel = endChannel, templateHeader=hd_temp)
     startChannel = 1024 + 700 # No Lines. Using the same as previous


### PR DESCRIPTION
This PR contains the NGC1333 additions to the first look script.  It also includes property mapping using the baseline pyspeckit model with more robust priors.  

Note, property mapping currently requires the up-to-date version of `pyspeckit`, which includes more fit order options.